### PR TITLE
Migrate from `Viddit` to `RapidSave`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'io.github.yvasyliev.telegramforwarderbot'
-version = '4.0.0'
+version = '4.1.0'
 
 java {
     toolchain {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,8 +7,8 @@ reddit:
   host: https://www.reddit.com
   user-agent: java:$group:v\${telegram.bot.version} (by /u/\${reddit.username})
   video-downloader:
-    uri: https://viddit.io/download
-    css-selector: a.download__item__info__actions__button
+    uri: https://rapidsave.com/info
+    css-selector: div.download-info a.downloadbutton
 
 spring:
   datasource:


### PR DESCRIPTION
## Description

Migrating from `Viddit` to `RapidSave`. For some reason, `Viddit` sets `Length=00:00:02` in every video metadata resulting in unexpected progress bar size in Telegram android client. `RapidSave` doesn't have such problem.

## Related Issue

`N/A`

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project’s code style and conventions
- [ ] I have added or updated Javadoc for public classes and methods
- [ ] I have added or updated unit tests as needed
- [x] All tests pass locally (`./gradlew build` or `gradlew.bat build` on Windows)
- [x] I have not committed any secrets (passwords, API keys, etc.)

## How Has This Been Tested?

The bot is tested in an internal environment.

## Additional Information

Add any other context or screenshots about the pull request here.

`N/A`