### PR TITLE
bugfix(publish-javadoc): fetch `gh-pages` branch before pushing

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -16,6 +16,12 @@ jobs:
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
 
+      - name: Fetch and merge remote gh-pages
+        run: |
+          git fetch origin gh-pages || true
+          git checkout -B gh-pages origin/gh-pages || git checkout -b gh-pages
+          git merge --allow-unrelated-histories master || true
+
       - name: Generate Javadoc
         run: ./gradlew javadoc
 
@@ -29,7 +35,6 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b gh-pages
           git add .
           git commit -m "Update Javadoc" || echo "No changes to commit"
           git push origin gh-pages


### PR DESCRIPTION
## Description

Fetch `gh-pages` branch before pushing.

## Related Issue

[Publish Javadoc #3](https://github.com/yvasyliev/telegram-forwarder-bot/actions/runs/16755458026)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project’s code style and conventions
- [ ] I have added or updated Javadoc for public classes and methods
- [ ] I have added or updated unit tests as needed
- [x] All tests pass locally (`./gradlew build` or `gradlew.bat build` on Windows)
- [x] I have not committed any secrets (passwords, API keys, etc.)

## How Has This Been Tested?

`N/A`

## Additional Information

`N/A`
