### PR TITLE
feat(reddit): add resilience with retry mechanism for subreddit fetching

### DIFF
--- a/telegram-forwarder-starter-reddit/src/main/java/io/github/yvasyliev/forwarder/telegram/reddit/configuration/RedditClientConfiguration.java
+++ b/telegram-forwarder-starter-reddit/src/main/java/io/github/yvasyliev/forwarder/telegram/reddit/configuration/RedditClientConfiguration.java
@@ -4,6 +4,7 @@ import io.github.yvasyliev.forwarder.telegram.reddit.service.RedditClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.resilience.annotation.EnableResilientMethods;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
@@ -16,6 +17,7 @@ import org.springframework.web.service.registry.ImportHttpServices;
  */
 @Configuration
 @ImportHttpServices(group = RedditClient.REDDIT_GROUP, types = RedditClient.class)
+@EnableResilientMethods
 public class RedditClientConfiguration {
     /**
      * Configures the OAuth2 Rest Client for Reddit.

--- a/telegram-forwarder-starter-reddit/src/main/java/io/github/yvasyliev/forwarder/telegram/reddit/service/RedditClient.java
+++ b/telegram-forwarder-starter-reddit/src/main/java/io/github/yvasyliev/forwarder/telegram/reddit/service/RedditClient.java
@@ -3,6 +3,7 @@ package io.github.yvasyliev.forwarder.telegram.reddit.service;
 import io.github.yvasyliev.forwarder.telegram.reddit.dto.Listing;
 import io.github.yvasyliev.forwarder.telegram.reddit.dto.Thing;
 import org.springframework.http.MediaType;
+import org.springframework.resilience.annotation.Retryable;
 import org.springframework.security.oauth2.client.annotation.ClientRegistrationId;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.service.annotation.GetExchange;
@@ -25,6 +26,7 @@ public interface RedditClient {
      * @param subreddit the name of the subreddit
      * @return a listing of new posts in the subreddit
      */
+    @Retryable
     @GetExchange("/r/{subreddit}/new?raw_json=1")
     Thing<Listing> getSubredditNew(@PathVariable String subreddit);
 }


### PR DESCRIPTION
## Description

Adds resilience with retry mechanism for subreddit fetching.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project’s code style and conventions
- [ ] I have added or updated Javadoc for public classes and methods
- [ ] I have added or updated unit tests as needed
- [x] All tests pass locally (`./gradlew build` or `gradlew.bat build` on Windows)
- [x] I have not committed any secrets (passwords, API keys, etc.)

## How Has This Been Tested?

Changes are tested locally.

## Additional Information

N/A
