### PR TITLE
chore: update version to `5.1.0`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ allprojects {
     apply plugin: 'io.spring.dependency-management'
 
     group = 'io.github.yvasyliev.forwarder.telegram'
-    version = '5.0.4'
+    version = '5.1.0'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## Description

Bumps `telegram-forwarder-bot` version to `5.1.0`.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (please describe): bump version

## Checklist

- [x] My code follows the project’s code style and conventions
- [ ] I have added or updated Javadoc for public classes and methods
- [ ] I have added or updated unit tests as needed
- [x] All tests pass locally (`./gradlew build` or `gradlew.bat build` on Windows)
- [x] I have not committed any secrets (passwords, API keys, etc.)

## How Has This Been Tested?

N/A

## Additional Information

N/A
