### PR TITLE
refactor: replace HttpHeaders usage with userAgent method in Jsoup connection

### DIFF
--- a/telegram-forwarder-starter-reddit/src/main/java/io/github/yvasyliev/forwarder/telegram/reddit/service/RedditVideoDownloader.java
+++ b/telegram-forwarder-starter-reddit/src/main/java/io/github/yvasyliev/forwarder/telegram/reddit/service/RedditVideoDownloader.java
@@ -3,7 +3,6 @@ package io.github.yvasyliev.forwarder.telegram.reddit.service;
 import io.github.yvasyliev.forwarder.telegram.reddit.dto.Link;
 import lombok.RequiredArgsConstructor;
 import org.jsoup.Jsoup;
-import org.springframework.http.HttpHeaders;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -32,7 +31,7 @@ public class RedditVideoDownloader {
                 .build()
                 .toUriString();
         var downloadInfo = Jsoup.connect(url)
-                .header(HttpHeaders.USER_AGENT, userAgent)
+                .userAgent(userAgent)
                 .get()
                 .select(cssSelector)
                 .first();

--- a/telegram-forwarder-starter-reddit/src/test/java/io/github/yvasyliev/forwarder/telegram/reddit/service/RedditVideoDownloaderTest.java
+++ b/telegram-forwarder-starter-reddit/src/test/java/io/github/yvasyliev/forwarder/telegram/reddit/service/RedditVideoDownloaderTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpHeaders;
 
 import java.io.IOException;
 import java.net.URI;
@@ -50,7 +49,7 @@ class RedditVideoDownloaderTest {
 
         when(post.permalink()).thenReturn(URI.create(PERMALINK).toURL());
         jsoup.when(() -> Jsoup.connect(VIDEO_DOWNLOADER_URI + "?url=" + PERMALINK)).thenReturn(connection);
-        when(connection.header(HttpHeaders.USER_AGENT, USER_AGENT)).thenReturn(connection);
+        when(connection.userAgent(USER_AGENT)).thenReturn(connection);
         when(connection.get()).thenReturn(document);
         when(document.select(CSS_SELECTOR)).thenReturn(elements);
     }


### PR DESCRIPTION
## Description

Replaces HttpHeaders usage with userAgent method in Jsoup connection.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project’s code style and conventions
- [ ] I have added or updated Javadoc for public classes and methods
- [ ] I have added or updated unit tests as needed
- [ ] All tests pass locally (`./gradlew build` or `gradlew.bat build` on Windows)
- [ ] I have not committed any secrets (passwords, API keys, etc.)

## How Has This Been Tested?

N/A

## Additional Information
N/A
