### PR TITLE
bugfix: add `ByteFilteringInputStream` to filter `null` bytes from input streams

### DIFF
--- a/telegram-forwarder-bot/src/main/resources/application.yml
+++ b/telegram-forwarder-bot/src/main/resources/application.yml
@@ -93,6 +93,8 @@ telegram:
 
 x:
   api:
+    bytes-to-exclude:
+      - 0x0
     uri-template: https://nitter.net/{profile}/rss
   video-service:
     uri: https://twitsave.com/info

--- a/telegram-forwarder-starter-x/src/main/java/io/github/yvasyliev/forwarder/telegram/x/configuration/XApiProperties.java
+++ b/telegram-forwarder-starter-x/src/main/java/io/github/yvasyliev/forwarder/telegram/x/configuration/XApiProperties.java
@@ -1,20 +1,25 @@
 package io.github.yvasyliev.forwarder.telegram.x.configuration;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import org.jsoup.helper.HttpConnection;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.validation.annotation.Validated;
 
+import java.util.Set;
+
 /**
  * Configuration properties for X API integration.
  *
- * @param uriTemplate the URI template for the X API endpoint
- * @param userAgent   the {@code User-Agent} header to use when making requests to the X API
+ * @param uriTemplate   the URI template for the X API endpoint
+ * @param userAgent     the {@code User-Agent} header to use when making requests to the X API
+ * @param bytesToFilter the set of bytes to filter from the response when fetching posts from the X API
  */
 @ConfigurationProperties("x.api")
 @Validated
 public record XApiProperties(
         @NotBlank String uriTemplate,
-        @NotBlank @DefaultValue(HttpConnection.DEFAULT_UA) String userAgent
+        @NotBlank @DefaultValue(HttpConnection.DEFAULT_UA) String userAgent,
+        @NotEmpty Set<Byte> bytesToFilter
 ) {}

--- a/telegram-forwarder-starter-x/src/main/java/io/github/yvasyliev/forwarder/telegram/x/configuration/XFeedEntryMessageSourceConfiguration.java
+++ b/telegram-forwarder-starter-x/src/main/java/io/github/yvasyliev/forwarder/telegram/x/configuration/XFeedEntryMessageSourceConfiguration.java
@@ -42,7 +42,10 @@ public class XFeedEntryMessageSourceConfiguration {
         var url = UriComponentsBuilder.fromUriString(xApiProperties.uriTemplate())
                 .build(profile)
                 .toURL();
-        var source = new FeedEntryMessageSource(new RssUrlResource(url, xApiProperties.userAgent()), profile);
+        var source = new FeedEntryMessageSource(
+                new RssUrlResource(url, xApiProperties.userAgent(), xApiProperties.bytesToFilter()),
+                profile
+        );
 
         source.setMetadataStore(new XMetadataStore(xLastFetchedPostService));
 

--- a/telegram-forwarder-starter-x/src/main/java/io/github/yvasyliev/forwarder/telegram/x/core/io/RssUrlResource.java
+++ b/telegram-forwarder-starter-x/src/main/java/io/github/yvasyliev/forwarder/telegram/x/core/io/RssUrlResource.java
@@ -1,12 +1,15 @@
 package io.github.yvasyliev.forwarder.telegram.x.core.io;
 
+import io.github.yvasyliev.forwarder.telegram.x.io.ByteFilteringInputStream;
 import lombok.EqualsAndHashCode;
 import org.springframework.core.io.UrlResource;
 import org.springframework.http.HttpHeaders;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Set;
 
 /**
  * Custom {@link UrlResource} that allows setting a custom {@code User-Agent} header when opening a connection to the
@@ -15,21 +18,36 @@ import java.net.URLConnection;
 @EqualsAndHashCode(callSuper = true)
 public class RssUrlResource extends UrlResource {
     private final String userAgent;
+    private final Set<Byte> bytesToFilter;
 
     /**
      * Creates a new instance of {@link RssUrlResource} with the given URL and {@code User-Agent} header.
      *
-     * @param url       the URL to access
-     * @param userAgent the {@code User-Agent} header to use when making requests to the URL
+     * @param url           the URL to access
+     * @param userAgent     the {@code User-Agent} header to use when making requests to the URL
+     * @param bytesToFilter the set of bytes to filter from the response when fetching posts from the URL
      */
-    public RssUrlResource(URL url, String userAgent) {
+    public RssUrlResource(URL url, String userAgent, Set<Byte> bytesToFilter) {
         super(url);
         this.userAgent = userAgent;
+        this.bytesToFilter = bytesToFilter;
     }
 
     @Override
     protected void customizeConnection(URLConnection con) throws IOException {
         super.customizeConnection(con);
         con.setRequestProperty(HttpHeaders.USER_AGENT, userAgent);
+    }
+
+    /**
+     * Returns an input stream that filters out {@code null} bytes (Unicode {@code 0x0}) which are invalid in XML. This
+     * prevents parsing errors when the feed contains corrupt data with embedded {@code null} bytes.
+     *
+     * @return a filtered input stream with {@code null} bytes removed
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return new ByteFilteringInputStream(super.getInputStream(), bytesToFilter);
     }
 }

--- a/telegram-forwarder-starter-x/src/main/java/io/github/yvasyliev/forwarder/telegram/x/io/ByteFilteringInputStream.java
+++ b/telegram-forwarder-starter-x/src/main/java/io/github/yvasyliev/forwarder/telegram/x/io/ByteFilteringInputStream.java
@@ -1,0 +1,64 @@
+package io.github.yvasyliev.forwarder.telegram.x.io;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+
+/**
+ * A custom input stream filter that removes {@code null} bytes ({@code 0x00}) from the stream.
+ */
+public class ByteFilteringInputStream extends FilterInputStream {
+    private final Set<Byte> bytesToFilter;
+
+    public ByteFilteringInputStream(InputStream in, Set<Byte> bytesToFilter) {
+        super(in);
+        this.bytesToFilter = bytesToFilter;
+    }
+
+    /**
+     * Reads the next byte from the stream, skipping any {@code null} bytes.
+     *
+     * @return {@inheritDoc}
+     * @throws IOException {@inheritDoc}
+     */
+    @Override
+    public int read() throws IOException {
+        var read = in.read();
+
+        while (bytesToFilter.contains((byte) read)) {
+            read = in.read();
+        }
+
+        return read;
+    }
+
+    /**
+     * Reads bytes from the stream into an array, filtering out {@code null} bytes.
+     *
+     * @param b   {@inheritDoc}
+     * @param off {@inheritDoc}
+     * @param len {@inheritDoc}
+     * @return {@inheritDoc}
+     * @throws IOException {@inheritDoc}
+     */
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        var temp = new byte[len];
+        var readCount = in.read(temp, 0, len);
+
+        if (readCount <= 0) {
+            return readCount;
+        }
+
+        var writePos = 0;
+
+        for (var i = 0; i < readCount; i++) {
+            if (!bytesToFilter.contains(temp[i])) {
+                b[off + writePos++] = temp[i];
+            }
+        }
+
+        return writePos > 0 ? writePos : read(b, off, len);
+    }
+}

--- a/telegram-forwarder-starter-x/src/main/java/io/github/yvasyliev/forwarder/telegram/x/io/package-info.java
+++ b/telegram-forwarder-starter-x/src/main/java/io/github/yvasyliev/forwarder/telegram/x/io/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * I/O-related classes for the X API integration.
+ */
+package io.github.yvasyliev.forwarder.telegram.x.io;

--- a/telegram-forwarder-starter-x/src/test/java/io/github/yvasyliev/forwarder/telegram/x/core/io/RssUrlResourceTest.java
+++ b/telegram-forwarder-starter-x/src/test/java/io/github/yvasyliev/forwarder/telegram/x/core/io/RssUrlResourceTest.java
@@ -1,10 +1,13 @@
 package io.github.yvasyliev.forwarder.telegram.x.core.io;
 
+import io.github.yvasyliev.forwarder.telegram.x.io.ByteFilteringInputStream;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 
+import java.io.IOException;
 import java.net.HttpURLConnection;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -14,10 +17,17 @@ class RssUrlResourceTest {
     void testCustomizeConnection() {
         var userAgent = "Test User Agent";
         var conn = mock(HttpURLConnection.class);
-        var resource = new RssUrlResource(mock(), userAgent);
+        var resource = new RssUrlResource(mock(), userAgent, null);
 
         assertDoesNotThrow(() -> resource.customizeConnection(conn));
 
         verify(conn).setRequestProperty(HttpHeaders.USER_AGENT, userAgent);
+    }
+
+    @Test
+    void testGetInputStream() throws IOException {
+        var resource = new RssUrlResource(mock(), null, null);
+
+        assertThat(resource.getInputStream()).isInstanceOf(ByteFilteringInputStream.class);
     }
 }

--- a/telegram-forwarder-starter-x/src/test/java/io/github/yvasyliev/forwarder/telegram/x/core/io/RssUrlResourceTest.java
+++ b/telegram-forwarder-starter-x/src/test/java/io/github/yvasyliev/forwarder/telegram/x/core/io/RssUrlResourceTest.java
@@ -6,18 +6,22 @@ import org.springframework.http.HttpHeaders;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class RssUrlResourceTest {
     @Test
     void testCustomizeConnection() {
         var userAgent = "Test User Agent";
         var conn = mock(HttpURLConnection.class);
-        var resource = new RssUrlResource(mock(), userAgent, null);
+        var resource = new RssUrlResource(mock(), userAgent, Set.of());
 
         assertDoesNotThrow(() -> resource.customizeConnection(conn));
 
@@ -26,7 +30,11 @@ class RssUrlResourceTest {
 
     @Test
     void testGetInputStream() throws IOException {
-        var resource = new RssUrlResource(mock(), null, null);
+        var url = mock(URL.class);
+        var urlConnection = mock(URLConnection.class);
+        var resource = new RssUrlResource(url, null, Set.of());
+
+        when(url.openConnection()).thenReturn(urlConnection);
 
         assertThat(resource.getInputStream()).isInstanceOf(ByteFilteringInputStream.class);
     }

--- a/telegram-forwarder-starter-x/src/test/java/io/github/yvasyliev/forwarder/telegram/x/io/ByteFilteringInputStreamTest.java
+++ b/telegram-forwarder-starter-x/src/test/java/io/github/yvasyliev/forwarder/telegram/x/io/ByteFilteringInputStreamTest.java
@@ -1,0 +1,73 @@
+package io.github.yvasyliev.forwarder.telegram.x.io;
+
+import lombok.Cleanup;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.FieldSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class ByteFilteringInputStreamTest {
+    private static final byte BYTE_TO_FILTER = 0x0;
+
+    @SuppressWarnings("checkstyle:ConstantName")
+    private static final Supplier<Stream<Arguments>> testRead = () -> Stream.of(
+            arguments(new byte[]{0x1}, 0x1),
+            arguments(new byte[]{0x0, 0x1}, 0x1),
+            arguments(new byte[]{0x0, 0x0}, -1),
+            arguments(new byte[]{0x1, 0x0}, 0x1)
+    );
+
+    @SuppressWarnings("checkstyle:ConstantName")
+    private static final Supplier<Stream<Arguments>> testReadBuffer = () -> Stream.of(
+            arguments(new byte[]{0x1}, 1, 1, new byte[]{0x7, 0x7, 0x7}, 1, new byte[]{0x7, 0x1, 0x7}),
+            arguments(new byte[]{0x0, 0x1}, 1, 1, new byte[]{0x7, 0x7, 0x7}, 1, new byte[]{0x7, 0x1, 0x7}),
+            arguments(new byte[]{0x0, 0x0}, 1, 1, new byte[]{0x7, 0x7, 0x7}, -1, new byte[]{0x7, 0x7, 0x7}),
+            arguments(new byte[]{0x1, 0x0}, 1, 2, new byte[]{0x7, 0x7, 0x7, 0x7}, 1, new byte[]{0x7, 0x1, 0x7, 0x7}),
+            arguments(
+                    new byte[]{0x1, 0x2, 0x0},
+                    1,
+                    3,
+                    new byte[]{0x7, 0x7, 0x7, 0x7, 0x7},
+                    2,
+                    new byte[]{0x7, 0x1, 0x2, 0x7, 0x7}
+            )
+    );
+
+    @ParameterizedTest
+    @FieldSource
+    void testRead(byte[] bytes, int expected) throws IOException {
+        @Cleanup var inputStream = new ByteFilteringInputStream(
+                new ByteArrayInputStream(bytes),
+                Set.of(BYTE_TO_FILTER)
+        );
+
+        var actual = assertDoesNotThrow(() -> inputStream.read());
+
+        assertEquals(expected, actual);
+    }
+
+    @ParameterizedTest
+    @FieldSource
+    void testReadBuffer(byte[] bytes, int off, int len, byte[] buffer, int expected, byte[] expectedBuffer)
+            throws IOException {
+        @Cleanup var inputStream = new ByteFilteringInputStream(
+                new ByteArrayInputStream(bytes),
+                Set.of(BYTE_TO_FILTER)
+        );
+
+        var actual = assertDoesNotThrow(() -> inputStream.read(buffer, off, len));
+
+        assertEquals(expected, actual);
+        assertArrayEquals(expectedBuffer, buffer);
+    }
+}


### PR DESCRIPTION
## Description

Adds `ByteFilteringInputStream` to filter `null` bytes from input streams

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project’s code style and conventions
- [x] I have added or updated Javadoc for public classes and methods
- [x] I have added or updated unit tests as needed
- [x] All tests pass locally (`./gradlew build` or `gradlew.bat build` on Windows)
- [x] I have not committed any secrets (passwords, API keys, etc.)

## How Has This Been Tested?

Tested locally

## Additional Information

N/A
